### PR TITLE
Add README, fix formatting, fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# deepcopy [![GoDoc](https://godoc.org/github.com/gavv/deepcopy?status.svg)](https://godoc.org/github.com/gavv/deepcopy)
+
+Package deepcopy implements a deep copy for arbitrary values.

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -1,3 +1,4 @@
+// Package deepcopy implements a deep copy for arbitrary values.
 package deepcopy
 
 import . "reflect"
@@ -7,7 +8,12 @@ type visit struct {
 	typ Type
 }
 
-// Returns a deep copy of the value passed in, copying all elements and exported fields. Note that Chan and Func values are are copied as shallow copies. This result of this function may not compare as equal with reflect.DeepEqual, as Func comparison will return false if both are not nil. Pointer hierarchies are preserved.
+// DeepCopy returns a deep copy of the value passed in, copying all elements and exported
+// fields.
+//
+// Note that Chan and Func values are are copied as shallow copies. This result of this
+// function may not compare as equal with reflect.DeepEqual, as Func comparison will return
+// false if both are not nil. Pointer hierarchies are preserved.
 func DeepCopy(i interface{}) interface{} {
 	if i == nil {
 		return nil
@@ -15,7 +21,12 @@ func DeepCopy(i interface{}) interface{} {
 	return DeepCopyValue(ValueOf(i)).Interface()
 }
 
-// Returns a deep copy of the data contained in the reflect.Value passed in, copying all elements and exported fields. Note that Chan and Func values are are copied as shallow copies. This result of this function may not compare as equal with reflect.DeepEqual, as Func comparison will return false if both are not nil. Pointer hierarchies are preserved.
+// DeepCopyValue returns a deep copy of the data contained in the reflect.Value passed in,
+// copying all elements and exported fields.
+//
+// Note that Chan and Func values are are copied as shallow copies. This result of this
+// function may not compare as equal with reflect.DeepEqual, as Func comparison will return
+// false if both are not nil. Pointer hierarchies are preserved.
 func DeepCopyValue(val Value) Value {
 	return deepCopyValue(val, make(map[visit]Value))
 }
@@ -24,7 +35,9 @@ func deepCopyValue(val Value, visited map[visit]Value) Value {
 	switch typ := val.Type(); typ.Kind() {
 
 	// Just return everything that can be shallow copied
-	case Bool, Int, Int8, Int16, Int32, Int64, Uint, Uint8, Uint16, Uint32, Uint64, Uintptr, Float32, Float64, Complex64, Complex128, Chan, Func, String:
+	case Bool,
+		Int, Int8, Int16, Int32, Int64, Uint, Uint8, Uint16, Uint32, Uint64, Uintptr,
+		Float32, Float64, Complex64, Complex128, Chan, Func, String:
 		return val
 
 	// Deal with the types which can contain references

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -17,24 +17,16 @@ type DeepEqualTest struct {
 	eq bool
 }
 
-type Node *Node
-
-func Addr(n Node, depth int) Node {
-	for i := 0; i < depth; i++ {
-		n2 := n
-		n = &n2
-	}
-	return n
+type Node struct {
+	Node *Node
 }
 
-func DeepCompare(a, b Node) bool {
-	for a != nil && b != nil {
-		if a == b {
-			return true
-		}
-		a, b = *a, *b
+func Addr(n *Node, depth int) *Node {
+	for i := 0; i < depth; i++ {
+		n2 := *n
+		n = &Node{&n2}
 	}
-	return false
+	return n
 }
 
 // Simple functions for DeepEqual tests.
@@ -43,14 +35,14 @@ var (
 )
 
 var (
-	node1 Node = new(Node)
-	node2 Node = Addr(node1, 1)
-	node3 Node = Addr(node1, 4)
-	node4 Node = Addr(node1, 4)
+	node1 *Node = new(Node)
+	node2 *Node = Addr(node1, 1)
+	node3 *Node = Addr(node1, 4)
+	node4 *Node = Addr(node1, 4)
 )
 
 func init() {
-	*node1 = node3
+	node1 = &Node{node3}
 }
 
 var deepEqualTests = []interface{}{


### PR DESCRIPTION
Hi!

This PR fixes comments to be more godoc-friendly and adds trivial README.

It also fixes tests for recent Go. Currently, `reflect.DeepEqual()` doesn't handle cyclic references in one rare case that is used in your tests, see [this issue](https://github.com/golang/go/issues/15610).

Note: GoDoc link in README points to https://godoc.org/github.com/gavv/deepcopy in my fork, you could change it to https://godoc.org/github.com/Popog/deepcopy after merging this.
